### PR TITLE
Nullref fix and memory leak fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file
 | website | https://forum.kerbalspaceprogram.com/index.php?/topic/194802-18-111-conformal-decals |
 | author  | Andrew Cassidy                                                                       |
 
+
+## 0.2.11 - Unreleased, changes submitted by Linuxgurugamer
+	Fixed nullref caused when an entry in _targets was null
+	Fixed memory leak caused by the OnDestroy() methods not being called due to them being virtual
+
+
 ## 0.2.10 - 2022-03-14
 
 ### Fixed

--- a/Source/ConformalDecals/ModuleConformalDecal.cs
+++ b/Source/ConformalDecals/ModuleConformalDecal.cs
@@ -283,7 +283,7 @@ namespace ConformalDecals {
             }
         }
 
-        public  void OnDestroy() {
+        public void OnDestroy() {
             // remove GameEvents
             if (HighLogic.LoadedSceneIsEditor) {
                 GameEvents.onEditorPartEvent.Remove(OnEditorEvent);
@@ -440,7 +440,8 @@ namespace ConformalDecals {
 
                 // update projection
                 foreach (var target in _targets) {
-                    target.Project(_orthoMatrix, decalProjectorTransform, _boundsRenderer.bounds, useBaseNormal);
+                    if (target != null) 
+                        target.Project(_orthoMatrix, decalProjectorTransform, _boundsRenderer.bounds, useBaseNormal);
                 }
             }
             else {

--- a/Source/ConformalDecals/ModuleConformalDecal.cs
+++ b/Source/ConformalDecals/ModuleConformalDecal.cs
@@ -283,7 +283,7 @@ namespace ConformalDecals {
             }
         }
 
-        public virtual void OnDestroy() {
+        public  void OnDestroy() {
             // remove GameEvents
             if (HighLogic.LoadedSceneIsEditor) {
                 GameEvents.onEditorPartEvent.Remove(OnEditorEvent);
@@ -577,7 +577,8 @@ namespace ConformalDecals {
 
             // render on each target object
             foreach (var target in _targets) {
-                target.Render(_decalMaterial, part.mpb, camera);
+                if (target != null)
+                    target.Render(_decalMaterial, part.mpb, camera);
             }
         }
     }

--- a/Source/ConformalDecals/ModuleConformalFlag.cs
+++ b/Source/ConformalDecals/ModuleConformalFlag.cs
@@ -48,13 +48,13 @@ namespace ConformalDecals {
             UpdateFlag();
         }
 
-        public override void OnDestroy() {
+        public  void OnDestroy() {
             if (HighLogic.LoadedSceneIsEditor) {
                 // Unregister flag change event
                 GameEvents.onMissionFlagSelect.Remove(OnEditorFlagSelected);
             }
             
-            base.OnDestroy();
+            //base.OnDestroy();
         }
 
         [KSPEvent(guiActive = false, guiActiveEditor = true, guiName = "#LOC_ConformalDecals_gui-select-flag")]

--- a/Source/ConformalDecals/ModuleConformalFlag.cs
+++ b/Source/ConformalDecals/ModuleConformalFlag.cs
@@ -53,9 +53,7 @@ namespace ConformalDecals {
                 // Unregister flag change event
                 GameEvents.onMissionFlagSelect.Remove(OnEditorFlagSelected);
             }
-            
-            //base.OnDestroy();
-        }
+                    }
 
         [KSPEvent(guiActive = false, guiActiveEditor = true, guiName = "#LOC_ConformalDecals_gui-select-flag")]
         public void SelectFlag() {

--- a/Source/ConformalDecals/ModuleConformalText.cs
+++ b/Source/ConformalDecals/ModuleConformalText.cs
@@ -220,7 +220,7 @@ namespace ConformalDecals {
             }
         }
 
-        public override void OnDestroy() {
+        public void OnDestroy() {
             if (HighLogic.LoadedSceneIsGame && _currentText != null) TextRenderer.UnregisterText(_currentText);
 
             // close all UIs
@@ -228,7 +228,7 @@ namespace ConformalDecals {
             if (_fillColorPickerController != null) _fillColorPickerController.Close();
             if (_outlineColorPickerController != null) _outlineColorPickerController.Close();
 
-            base.OnDestroy();
+            //base.OnDestroy();
         }
 
         protected override void OnDetach() {

--- a/Source/ConformalDecals/ModuleConformalText.cs
+++ b/Source/ConformalDecals/ModuleConformalText.cs
@@ -227,8 +227,6 @@ namespace ConformalDecals {
             if (_textEntryController != null) _textEntryController.Close();
             if (_fillColorPickerController != null) _fillColorPickerController.Close();
             if (_outlineColorPickerController != null) _outlineColorPickerController.Close();
-
-            //base.OnDestroy();
         }
 
         protected override void OnDetach() {


### PR DESCRIPTION
        Fixed nullref caused when an entry in _targets was null
        Fixed memory leak caused by the OnDestroy() methods not being called due to them being virtual
